### PR TITLE
feat: ✨ Add browser search locations

### DIFF
--- a/Browserino.xcodeproj/project.pbxproj
+++ b/Browserino.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		664FDF222CE4AA6B009766AA /* BrowserUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664FDF212CE4AA6B009766AA /* BrowserUtil.swift */; };
+		669247902CEB48A5006A8C8B /* BrowserSearchLocationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6692478F2CEB48A5006A8C8B /* BrowserSearchLocationsTab.swift */; };
 		9830F0A62C119A3000D69C88 /* BrowserinoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9830F0A52C119A3000D69C88 /* BrowserinoApp.swift */; };
 		9830F0A82C119A3000D69C88 /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9830F0A72C119A3000D69C88 /* PromptView.swift */; };
 		9830F0AA2C119A3100D69C88 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9830F0A92C119A3100D69C88 /* Assets.xcassets */; };
@@ -31,6 +32,7 @@
 
 /* Begin PBXFileReference section */
 		664FDF212CE4AA6B009766AA /* BrowserUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserUtil.swift; sourceTree = "<group>"; };
+		6692478F2CEB48A5006A8C8B /* BrowserSearchLocationsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSearchLocationsTab.swift; sourceTree = "<group>"; };
 		9830F0A22C119A3000D69C88 /* Browserino.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Browserino.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9830F0A52C119A3000D69C88 /* BrowserinoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserinoApp.swift; sourceTree = "<group>"; };
 		9830F0A72C119A3000D69C88 /* PromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptView.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				989B17FA2C1710D70039441B /* AppsTab.swift */,
 				989B17F62C16FD260039441B /* GeneralTab.swift */,
 				989B17F82C170C160039441B /* AboutTab.swift */,
+				6692478F2CEB48A5006A8C8B /* BrowserSearchLocationsTab.swift */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 				989B17F72C16FD260039441B /* GeneralTab.swift in Sources */,
 				989B17FD2C17400A0039441B /* EditAppForm.swift in Sources */,
 				989B17EF2C16F7640039441B /* PromptItem.swift in Sources */,
+				669247902CEB48A5006A8C8B /* BrowserSearchLocationsTab.swift in Sources */,
 				989B17F92C170C160039441B /* AboutTab.swift in Sources */,
 				9830F0BE2C11DEBB00D69C88 /* View+If.swift in Sources */,
 				989B17F52C16FC690039441B /* ShortcutButton.swift in Sources */,

--- a/Browserino.xcodeproj/project.pbxproj
+++ b/Browserino.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		664FDF222CE4AA6B009766AA /* BrowserUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664FDF212CE4AA6B009766AA /* BrowserUtil.swift */; };
 		9830F0A62C119A3000D69C88 /* BrowserinoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9830F0A52C119A3000D69C88 /* BrowserinoApp.swift */; };
 		9830F0A82C119A3000D69C88 /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9830F0A72C119A3000D69C88 /* PromptView.swift */; };
 		9830F0AA2C119A3100D69C88 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9830F0A92C119A3100D69C88 /* Assets.xcassets */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		664FDF212CE4AA6B009766AA /* BrowserUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserUtil.swift; sourceTree = "<group>"; };
 		9830F0A22C119A3000D69C88 /* Browserino.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Browserino.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9830F0A52C119A3000D69C88 /* BrowserinoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserinoApp.swift; sourceTree = "<group>"; };
 		9830F0A72C119A3000D69C88 /* PromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptView.swift; sourceTree = "<group>"; };
@@ -64,6 +66,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		664FDF202CE4A9E1009766AA /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				664FDF212CE4AA6B009766AA /* BrowserUtil.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		9830F0992C119A3000D69C88 = {
 			isa = PBXGroup;
 			children = (
@@ -109,6 +119,7 @@
 		9830F0B72C11B08B00D69C88 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				664FDF202CE4A9E1009766AA /* Utils */,
 				989B17F12C16FC420039441B /* Preferences */,
 				989B17F02C16FBDF0039441B /* Prompt */,
 				9830F0B82C11B09700D69C88 /* BlurredView.swift */,
@@ -241,6 +252,7 @@
 				989B17F52C16FC690039441B /* ShortcutButton.swift in Sources */,
 				9830F0C32C11DEED00D69C88 /* ButtonStyles.swift in Sources */,
 				9830F0B62C119CD800D69C88 /* main.swift in Sources */,
+				664FDF222CE4AA6B009766AA /* BrowserUtil.swift in Sources */,
 				9830F0B92C11B09700D69C88 /* BlurredView.swift in Sources */,
 				9830F0C72C11E87300D69C88 /* Array+RawRepresentable.swift in Sources */,
 			);

--- a/Browserino/Views/Preferences/BrowsersTab.swift
+++ b/Browserino/Views/Preferences/BrowsersTab.swift
@@ -10,18 +10,7 @@ import SwiftUI
 struct BrowsersTab: View {
     @AppStorage("browsers") private var browsers: [URL] = []
     @AppStorage("hiddenBrowsers") private var hiddenBrowsers: [URL] = []
-    
-    func loadBrowsers() -> [URL] {
-        return NSWorkspace.shared.urlsForApplications(toOpen: URL(string: "https:")!)
-            .filter {
-                let pathComponents = $0.pathComponents
-                
-                return pathComponents[1] == "Applications" || pathComponents[pathComponents.count - 1] == "Safari.app"
-            }
-            .filter { Bundle(url: $0) != nil }
-            .filter { Bundle(url: $0)!.bundleIdentifier != Bundle.main.bundleIdentifier }
-    }
-    
+
     func move(from source: IndexSet, to destination: Int) {
         browsers.move(fromOffsets: source, toOffset: destination)
     }
@@ -78,7 +67,7 @@ struct BrowsersTab: View {
             }
             .onAppear {
                 if browsers.isEmpty {
-                    browsers = loadBrowsers()
+                    browsers = BrowserUtil.loadBrowsers()
                 }
             }
             

--- a/Browserino/Views/Preferences/GeneralTab.swift
+++ b/Browserino/Views/Preferences/GeneralTab.swift
@@ -11,17 +11,6 @@ struct GeneralTab: View {
     @State private var isDefault = false
     @AppStorage("browsers") private var browsers: [URL] = []
     
-    func loadBrowsers() -> [URL] {
-        return NSWorkspace.shared.urlsForApplications(toOpen: URL(string: "https:")!)
-            .filter {
-                let pathComponents = $0.pathComponents
-                
-                return pathComponents[1] == "Applications" || pathComponents[pathComponents.count - 1] == "Safari.app"
-            }
-            .filter { Bundle(url: $0) != nil }
-            .filter { Bundle(url: $0)!.bundleIdentifier != Bundle.main.bundleIdentifier }
-    }
-    
     func defaultBrowser() -> String? {
         guard let browserUrl = NSWorkspace.shared.urlForApplication(toOpen: URL(string: "https:")!) else {
             return nil
@@ -63,7 +52,7 @@ struct GeneralTab: View {
                 
                 VStack(alignment: .leading) {
                     Button(action: {
-                        browsers = loadBrowsers()
+                        browsers = BrowserUtil.loadBrowsers()
                     }) {
                         Text("Rescan")
                     }

--- a/Browserino/Views/Preferences/PreferencesView.swift
+++ b/Browserino/Views/Preferences/PreferencesView.swift
@@ -40,6 +40,12 @@ struct PreferencesView: View {
                 }
                 .tag(2)
             
+            BrowserSearchLocationsTab()
+                .tabItem {
+                    Label("Locations", systemImage: "gear")
+                }
+                .tag(2)
+
             AboutTab()
                 .tabItem {
                     Label("About", systemImage: "gear")

--- a/Browserino/Views/Utils/BrowserUtil.swift
+++ b/Browserino/Views/Utils/BrowserUtil.swift
@@ -1,0 +1,40 @@
+//
+//  BrowserUtil.swift
+//  Browserino
+//
+//  Created by byt3m4st3r.
+//
+
+import AppKit
+import Foundation
+
+class BrowserUtil {
+    static func loadBrowsers() -> [URL] {
+        // URL representing the "https" scheme which browsers can handle
+        guard let url = URL(string: "https:") else {
+            return []
+        }
+
+        // Fetch all applications that can open the https scheme
+        let urlsForApplications = NSWorkspace.shared.urlsForApplications(toOpen: url)
+
+        let validDirectories = [
+            "/Applications",
+        ]
+
+        // Filter the browsers to include only those in the specified directories
+        var filteredUrlsForApplications = urlsForApplications.filter { urlsForApplication in
+            // Check if the browser's path starts with any of the valid directories
+            validDirectories.contains { urlsForApplication.path.hasPrefix($0) }
+        }
+
+        // Always include Safari by adding it explicitly if not already present
+        if let safariURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Safari") {
+            if !filteredUrlsForApplications.contains(safariURL) {
+                filteredUrlsForApplications.append(safariURL)
+            }
+        }
+
+        return filteredUrlsForApplications
+    }
+}


### PR DESCRIPTION
- Add a new tab for browser search locations
- Always add per default the “/Applications” directory
- Allow adding and deleting of new browser location directories
- Persist the directories in the app storage
- Useful, f.e. for company devices

![image](https://github.com/user-attachments/assets/d14b060e-5e05-4567-86f4-3bd25aac8de8)

ℹ️ Depends on respectively includes also the changes of https://github.com/AlexStrNik/Browserino/pull/8