### PR TITLE
feat: Esc to close PromptView

### DIFF
--- a/Browserino/Views/Prompt/PromptView.swift
+++ b/Browserino/Views/Prompt/PromptView.swift
@@ -149,6 +149,12 @@ struct PromptView: View {
                     }) {}
                     .opacity(0)
                     .keyboardShortcut(.return, modifiers: [.shift])
+
+                    Button(action: {
+                        NSApplication.shared.keyWindow?.close()
+                    }) {}
+                    .opacity(0)
+                    .keyboardShortcut(.cancelAction)
                 }
                 .onAppear {
                     focused.toggle()


### PR DESCRIPTION
I want the ability to close the PromptView using Esc key, instead of just clicking outside the view.
This is my first SwitfUI patch so please let me know if I did it wrong 🙏 