### PR TITLE
feat: drag to reorder rules

### DIFF
--- a/Browserino/Extensions/View+ScrollEdgeDisabled.swift
+++ b/Browserino/Extensions/View+ScrollEdgeDisabled.swift
@@ -11,9 +11,7 @@ extension View {
     @ViewBuilder
     func scrollEdgeEffectDisabledCompat() -> some View {
         if #available(macOS 26.0, *) {
-            self
-                .scrollEdgeEffectStyle(.soft, for: .all)
-                .scrollEdgeEffectDisabled(true, for: .all)
+            self.scrollEdgeEffectStyle(.soft, for: .all)
         } else {
             self
         }

--- a/Browserino/Views/Preferences/RulesTab.swift
+++ b/Browserino/Views/Preferences/RulesTab.swift
@@ -86,7 +86,11 @@ struct RuleItem: View {
 
 struct RulesTab: View {
     @AppStorage("rules") private var rules: [Rule] = []
-    
+
+    private func move(from source: IndexSet, to destination: Int) {
+        rules.move(fromOffsets: source, toOffset: destination)
+    }
+
     var body: some View {
         VStack (alignment: .leading) {
             List {
@@ -97,9 +101,10 @@ struct RulesTab: View {
                         rule: rule
                     )
                 }
+                .onMove(perform: move)
             }
-            
-            Text("Type regex and choose app in which links will be opened without prompt")
+
+            Text("Drag and drop to reorder. Type regex and choose app in which links will be opened without prompt. The first matching rule wins.")
                 .font(.subheadline)
                 .foregroundStyle(.primary.opacity(0.5))
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Adds drag-to-reorder for entries in the Rules tab via `.onMove`, mirroring the existing pattern in `BrowsersTab`. Order is persisted through `@AppStorage("rules")` and directly controls evaluation priority (first match wins in `BrowserinoApp.handleURLs`).
- Drive-by fix: removes a call to `scrollEdgeEffectDisabled(_:for:)` in `View+ScrollEdgeDisabled.swift` that does not exist in the public SwiftUI API of the macOS 26.4 SDK (Xcode 26.4), which currently breaks the build on main.

## Test plan
- [x] Build succeeds on Xcode 26.4 / macOS 26.4
- [x] Rules can be dragged up/down in Preferences → Rules
- [x] New order persists across Preferences close/reopen and app relaunch
- [x] A reordered specific rule correctly shadows/unshadows a broad rule when opening matching URLs
- [x] The "Add new rule" row cannot be dragged or displaced