### PR TITLE
Update Readme.md - Remove deprecated flag `--no-quarantine`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,36 @@ Inspired by great [Browserosaurus](https://github.com/will-stone/browserosaurus)
 
 # Installation
 
+## Using Homebrew
+
+1. Tap and install
+
 ```bash
 brew tap AlexStrNik/Browserino
-brew install browserino --no-quarantine
+brew install browserino
 ```
 
+2. Launch the app once (or open it from Applications)
+
+```bash
+browserino
+```
+
+3. If macOS blocks the app, go to  
+`System Settings → Privacy & Security`
+
+
+<details>
+<summary>Click **Allow Anyway**, then reopen the app. (Screenshot) </summary>
+
+<img width="760" height="633" alt="Image" src="https://github.com/user-attachments/assets/18f19f5a-eba6-4a79-9f08-a57988e2f5aa" />
+
+</details>
+
+4. macOS may show one more warning dialog.  
+Click **Open** to confirm and launch the app.
+
+## Manual
 Or download Browserino from the [releases page](https://github.com/AlexStrNik/Browserino/releases).
 
 If you want to support the app, you can buy it on [Gumroad](https://alexstrnik.gumroad.com/l/browserino).


### PR DESCRIPTION
## Changes
1. Remove deprecated flag `--no-quarantine`
2. Added screenshot and instructions.

## Issues
- Install with `--no-quarantine` fails with 
```
Error: Calling the `--[no-]quarantine` switch is disabled! There is no replacement.
```

<img width="841" height="199" alt="image" src="https://github.com/user-attachments/assets/ab36a17e-b826-4cc2-bcb6-1c515ccc53a0" />
