### PR TITLE
Fix scrollEdgeEffectDisabledCompat build on Xcode 26.5

### DIFF
--- a/Browserino/Extensions/View+ScrollEdgeDisabled.swift
+++ b/Browserino/Extensions/View+ScrollEdgeDisabled.swift
@@ -11,9 +11,7 @@ extension View {
     @ViewBuilder
     func scrollEdgeEffectDisabledCompat() -> some View {
         if #available(macOS 26.0, *) {
-            self
-                .scrollEdgeEffectStyle(.soft, for: .all)
-                .scrollEdgeEffectDisabled(true, for: .all)
+            self.scrollEdgeEffectStyle(nil, for: [.top, .bottom, .leading, .trailing])
         } else {
             self
         }


### PR DESCRIPTION
## Summary

Fixes a build break on Xcode 26.5 / macOS 26.5 SDK in `Browserino/Extensions/View+ScrollEdgeDisabled.swift`.

## Problem

The `#available(macOS 26.0, *)` branch fails to compile with two errors:

```
error: value of type 'some View' has no member 'scrollEdgeEffectDisabled'
error: cannot infer contextual base in reference to member 'all'
```

Diagnosis:

- `scrollEdgeEffectDisabled(_:for:)` symbol is present in `SwiftUI.tbd` but is **not exposed** in the public `.swiftinterface` shipped in macOS 26.5 SDK. It appears to have been dropped between macOS 26 betas (when this code was written) and the final SDK.
- `Edge.Set.all` is not a defined member of `Edge.Set`.

## Fix

Pass `nil` to `scrollEdgeEffectStyle` with explicit edges. The original code applied `.soft` style and then called `.disabled(true, ...)` — the net behavior was "disabled", which `nil` expresses directly.

```diff
-self
-    .scrollEdgeEffectStyle(.soft, for: .all)
-    .scrollEdgeEffectDisabled(true, for: .all)
+self.scrollEdgeEffectStyle(nil, for: [.top, .bottom, .leading, .trailing])
```

## Test plan

- [x] `xcodebuild -project Browserino.xcodeproj -scheme Browserino -configuration Release build` succeeds on Xcode 26.5 (Build 17F42)
- [x] App launches, menu bar item appears, browser-selector prompt opens on link clicks
- [ ] Visual regression check on the scrolling list in the prompt — should look the same as on earlier macOS 26 builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)